### PR TITLE
feat: add WebSocket synchronization for item updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,15 @@ Eine moderne Shopping-List-Anwendung mit sicherer Benutzerauthentifizierung, per
     - **Sichere Operation**: Warnung vor Datenverlust, Bestätigungsdialog erforderlich
     - Navigation über Benutzermenü: "💾 Datenbank-Backup"
 - ✅ **Real-time Updates mit WebSocket**: Live-Synchronisation der Einkaufsliste zwischen mehreren Clients
-  - **Automatische Synchronisation**: Änderungen werden sofort an alle verbundenen Clients übertragen
+  - **Automatische Synchronisation**: Alle Änderungen werden sofort an alle verbundenen Clients übertragen
+    - **Item hinzufügen**: Neue Items erscheinen sofort auf allen Clients
+    - **Item löschen**: Gelöschte Items verschwinden sofort überall
+    - **Item aktualisieren**: Mengen-Änderungen und Abteilungs-Zuordnungen werden live synchronisiert
   - **Smart Broadcasting**: Nur andere Clients werden benachrichtigt (nicht der Absender selbst)
+  - **Intelligentes Event-Handling**:
+    - Neue Items → `item:add` Event
+    - Gelöschte Items → `item:delete` Event
+    - Aktualisierte Items (Menge, Abteilung) → `item:update` Event
   - **Auto-Reconnection**: Automatische Wiederverbindung bei Verbindungsabbruch mit exponentiellem Backoff
   - **Heartbeat-Mechanismus**: Ping/Pong alle 30 Sekunden zur Erkennung stagnierender Verbindungen
   - **Message Queue**: Bis zu 100 Nachrichten werden während Offline-Phasen gepuffert

--- a/client/ARCHITECTURE.md
+++ b/client/ARCHITECTURE.md
@@ -1223,11 +1223,34 @@ WebSocket integration enables real-time collaborative shopping lists where multi
 The WebSocket feature has been successfully implemented with the following components:
 
 - ✅ **WebSocket Module** ([client/src/data/websocket.ts](client/src/data/websocket.ts)) - Connection management, auto-reconnection, heartbeat
-- ✅ **State Integration** ([client/src/state/shopping-list-state.ts](client/src/state/shopping-list-state.ts)) - Real-time state updates
+- ✅ **State Integration** ([client/src/state/shopping-list-state.ts](client/src/state/shopping-list-state.ts)) - Real-time state updates with intelligent event dispatching
+  - **New items** → `broadcastItemAdd()` → `item:add` event
+  - **Deleted items** → `broadcastItemDelete()` → `item:delete` event
+  - **Updated items** (quantity, department) → `broadcastItemUpdate()` → `item:update` event
+  - **Smart broadcasting**: Distinguishes between add and update based on existing state
+- ✅ **UI Integration** ([client/src/ui/shopping-list-ui.ts](client/src/ui/shopping-list-ui.ts)) - Department assignment uses updateItem() for optimized WebSocket sync
 - ✅ **Server Endpoint** ([server/src/websocket_manager.py](server/src/websocket_manager.py), [server/src/main.py](server/src/main.py)) - Connection manager and broadcasting
 - ✅ **ConnectionStatus UI** ([client/src/ui/components/connection-status.ts](client/src/ui/components/connection-status.ts)) - Visual connection indicator
 - ✅ **Entry Point Integration** ([client/src/script.ts](client/src/script.ts)) - Automatic connection on app load
 - ✅ **Comprehensive Tests** ([client/src/data/websocket.test.ts](client/src/data/websocket.test.ts)) - 12 passing tests
+
+### Synchronized Operations
+
+All shopping list modifications are now synchronized in real-time:
+
+1. **Adding Items**:
+   - If item is new → Sends `item:add` event
+   - If item exists (quantity merge) → Sends `item:update` event
+   - Server merges quantities for same item+date combinations
+
+2. **Deleting Items**:
+   - Sends `item:delete` event with item ID
+   - All connected clients remove the item immediately
+
+3. **Updating Items**:
+   - **Quantity changes** (re-adding with new quantity) → `item:update` event
+   - **Department assignment** (Edit button) → `item:update` event
+   - Uses optimized `updateItem()` method to avoid unnecessary API calls
 
 **How to Enable**:
 

--- a/client/src/ui/shopping-list-ui.ts
+++ b/client/src/ui/shopping-list-ui.ts
@@ -49,8 +49,8 @@ async function handleEditItem(itemId: string): Promise<void> {
     const updatedItem = await convertItemToProduct(itemId, departmentId);
 
     if (updatedItem) {
-      // Reload items to reflect changes
-      await shoppingListState.loadItems();
+      // Update item in state and broadcast to other clients
+      shoppingListState.updateItem(updatedItem);
       // UI updates automatically via state subscription
       showSuccess('Produkt erfolgreich zugewiesen');
     } else {


### PR DESCRIPTION
- Add updateItem() method to shopping-list-state for local updates with WebSocket broadcast
- Implement intelligent event dispatching in addItem():
  * New items → broadcastItemAdd() (item:add event)
  * Existing items (quantity merge) → broadcastItemUpdate() (item:update event)
- Optimize department assignment in shopping-list-ui:
  * Use updateItem() instead of loadItems() to avoid unnecessary API calls
  * Immediate WebSocket synchronization of department changes
- Update README.md with comprehensive WebSocket feature documentation:
  * Document all synchronized operations (add, delete, update)
  * Add intelligent event-handling description
- Update client/ARCHITECTURE.md with implementation details:
  * Document updateItem() method and smart broadcasting logic
  * Add synchronized operations section

All item modifications now sync in real-time:
✅ Adding items (new or quantity merge)
✅ Deleting items
✅ Updating quantities (re-adding existing items)
✅ Assigning departments (Edit button)

🤖 Generated with [Claude Code](https://claude.com/claude-code)